### PR TITLE
Update Ember Montevideo meetup link

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       <h2>Communities</h2>
       <ul>
         <li><a href="https://reactjsuy.now.sh/">react.js.uy</a> - A community to learn and share react experiences</li>
-        <li><a href="https://github.com/ember-montevideo/meetups#readme">Montevideo Ember Meetup</a> - A community to learn and share ember.js experiences</li>
+        <li><a href="http://ember.js.uy">Montevideo Ember Meetup</a> - A community to learn and share ember.js experiences</li>
         <li><a href="https://www.meetup.com/Angular-MVD/">Angular MVD</a> - A community to learn and share Angular experiences</li>
       </ul>
       <h2>How I list my community here?</h2>


### PR DESCRIPTION
Hi, 

We now have site for `ember-montevideo` meetup https://ember-montevideo.github.io/ 

This PR changes the link from the github url to `ember.js.uy` based on:


>I run a Uruguayan JS community, can I have a js.uy domain?
>
>Sure, the idea is to give the whole Uruguayan JS community a stronger image not to own anything so please ✉️ and I can add your CNAME to the Antel DNS.


It would be awesome if you could add the CNAME for ember.js.uy to ember-montevideo.github.io, I already open a [PR](https://github.com/ember-montevideo/ember-montevideo.github.io/pull/4) with the other work needed in `ember-montevideo`

Thanks!

